### PR TITLE
perform tests with cold and warm cache

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,20 +34,26 @@ jobs:
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make poetry-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make poetry-clean-cache
           make poetry-clean-venv
           make poetry-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make poetry-lock
+
+      - name: lock warm
+        run: |
+          make poetry-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make poetry-lock
 
       - name: install cold
         run: |
-         make poetry-clean-cache
-         make poetry-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make poetry-install
+          make poetry-clean-cache
+          make poetry-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make poetry-install
 
       - name: install warm
         run: |
@@ -55,9 +61,15 @@ jobs:
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make poetry-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make poetry-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make poetry-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make poetry-update
 
       - name: add package
@@ -72,7 +84,7 @@ jobs:
           TIMESTAMP=$(date +%s)
           mkdir -p "poetry"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "poetry,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY
@@ -108,20 +120,26 @@ jobs:
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pdm-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make pdm-clean-cache
           make pdm-clean-venv
           make pdm-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-lock
+
+      - name: lock warm
+        run: |
+          make pdm-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pdm-lock
 
       - name: install cold
         run: |
-         make pdm-clean-cache
-         make pdm-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make pdm-install
+          make pdm-clean-cache
+          make pdm-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-install
 
       - name: install warm
         run: |
@@ -129,9 +147,15 @@ jobs:
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pdm-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make pdm-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pdm-update
 
       - name: add package
@@ -146,7 +170,7 @@ jobs:
           TIMESTAMP=$(date +%s)
           mkdir -p "pdm"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "pdm,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY
@@ -182,20 +206,26 @@ jobs:
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pipenv-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make pipenv-clean-cache
           make pipenv-clean-venv
           make pipenv-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pipenv-lock
+
+      - name: lock warm
+        run: |
+          make pipenv-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pipenv-lock
 
       - name: install cold
         run: |
-         make pipenv-clean-cache
-         make pipenv-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make pipenv-install
+          make pipenv-clean-cache
+          make pipenv-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pipenv-install
 
       - name: install warm
         run: |
@@ -203,9 +233,15 @@ jobs:
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pipenv-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make pipenv-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pipenv-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pipenv-update
 
       - name: add package
@@ -220,7 +256,7 @@ jobs:
           TIMESTAMP=$(date +%s)
           mkdir -p "pipenv"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "pipenv,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY
@@ -256,20 +292,26 @@ jobs:
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pip-tools-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make pip-tools-clean-cache
           make pip-tools-clean-venv
           make pip-tools-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pip-tools-lock
+
+      - name: lock warm
+        run: |
+          make pip-tools-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pip-tools-lock
 
       - name: install cold
         run: |
-         make pip-tools-clean-cache
-         make pip-tools-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make pip-tools-install
+          make pip-tools-clean-cache
+          make pip-tools-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pip-tools-install
 
       - name: install warm
         run: |
@@ -277,9 +319,15 @@ jobs:
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pip-tools-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make pip-tools-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pip-tools-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make pip-tools-update
 
       - name: add package
@@ -294,7 +342,7 @@ jobs:
           TIMESTAMP=$(date +%s)
           mkdir -p "pip-tools"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "pip-tools,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -378,20 +378,26 @@ jobs:
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make uv-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make uv-clean-cache
           make uv-clean-venv
           make uv-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make uv-lock
+
+      - name: lock warm
+        run: |
+          make uv-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make uv-lock
 
       - name: install cold
         run: |
-         make uv-clean-cache
-         make uv-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make uv-install
+          make uv-clean-cache
+          make uv-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make uv-install
 
       - name: install warm
         run: |
@@ -399,9 +405,15 @@ jobs:
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make uv-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make uv-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make uv-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make uv-update
 
       - name: add package
@@ -416,7 +428,7 @@ jobs:
           TIMESTAMP=$(date +%s)
           mkdir -p "uv"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "uv,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY

--- a/site/index.js
+++ b/site/index.js
@@ -110,7 +110,7 @@ for (const graph in data) {
     data[graph].datasets[0].backgroundColor.push(colors[i]);
     data[graph].datasets[0].borderColor.push(newShade(colors[i], -50));
   });
-  if (graph === "install") {
+  if (data[graph].datasets.length > 1) {
     data[graph].datasets[1].backgroundColor = [];
     data[graph].datasets[1].borderColor = [];
     data[graph].datasets[1].data.forEach(function (dataset, i) {

--- a/templates/workflow_tool.yml
+++ b/templates/workflow_tool.yml
@@ -23,20 +23,26 @@
           /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make ${TOOL}-import
 
-      - name: lock
+      - name: lock cold
         run: |
           make ${TOOL}-clean-cache
           make ${TOOL}-clean-venv
           make ${TOOL}-clean-lock
-          /usr/bin/time --output=timings/lock.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make ${TOOL}-lock
+
+      - name: lock warm
+        run: |
+          make ${TOOL}-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make ${TOOL}-lock
 
       - name: install cold
         run: |
-         make ${TOOL}-clean-cache
-         make ${TOOL}-clean-venv
-         /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
-           make ${TOOL}-install
+          make ${TOOL}-clean-cache
+          make ${TOOL}-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make ${TOOL}-install
 
       - name: install warm
         run: |
@@ -44,9 +50,15 @@
           /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make ${TOOL}-install
 
-      - name: update
+      - name: update cold
         run: |
-          /usr/bin/time --output=timings/update.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+          make ${TOOL}-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make ${TOOL}-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
             make ${TOOL}-update
 
       - name: add package
@@ -61,7 +73,7 @@
           TIMESTAMP=$(date +%s)
           mkdir -p "$TOOL"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
-          for stat in "tooling" "import" "lock" "install-cold" "install-warm" "update" "add-package"; do
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
             echo "${TOOL},$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
add cold/warm cache variants to "lock" and "update".  [Sample results here](https://dimbleby.github.io/python-package-manager-shootout/), via the gh-pages branch of my fork.

Various things one could quibble with here...

It's a bit unclear how "cold" the cold versions should be:
-  does it make sense to remove the lockfile before "lock warm"?  
   - I think yes, it feels to me as though the point of "lock warm" is to create the lockfile.  
   - Probably it doesn't make a difference 
- why not remove the virtualenv before "update cold"?  
  - the answer is that I tried that but one of the tools (I forget which!) expects that the virtual environment is there in its interpretation of "update", so it just doesn't work
  - well all benchmarks are flawed, clearly "update" does not mean the same thing for the different tools, what can you do?

I would have done cold and warm for "add package" too but it's a little harder: because after you've added the package the first time, it's not quite trivial to restore the state in readiness for adding it again.

I haven't thought too hard about what the website will look like during the 24 hours where some workflows are the old ones and some are the new ones.  I believe the result should be three bars on some of the charts, which would seem tolerable - but that is only a thought experiment.