### PR TITLE
Keep poetry virtual environment away from its cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ TOOLS := poetry
 .PHONY: poetry-tooling poetry-import poetry-clean-cache poetry-clean-venv poetry-clean-lock poetry-lock poetry-install poetry-add-package poetry-version
 poetry-tooling:
 	curl -sSL https://install.python-poetry.org | python3 -
+	poetry config virtualenvs.in-project true
 poetry-import:
 	cd poetry; poetry add $$(sed -e 's/#.*//' -e '/^$$/ d' < ../requirements.txt)
 poetry-clean-cache: pip-clean
 	rm -rf ~/.cache/pypoetry
 poetry-clean-venv:
-	cd poetry; poetry env remove python || true
+	cd poetry; poetry env remove --all || true
 poetry-clean-lock:
 	rm -f poetry/poetry.lock
 poetry-lock:


### PR DESCRIPTION
per https://github.com/lincolnloop/python-package-manager-shootout/pull/15#issuecomment-1950141763

- poetry's "cold update" is currently an outlier
- the reason is that by default poetry puts virtual environments in its cache directory
- so while all the other tools are working in an existing virtual environment but with empty cache, poetry is working from a completely fresh start

There's definitely a case to be made that this is poetry's own silly fault, if it didn't want people who clear the cache also to clear their venv then it shouldn't have done that.  

But I think it is more in the spirit of what the benchmark is trying to measure to keep these things separate, and keep the tests more comparable.