### PR TITLE
install poetry with pipx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ pip-clean:
 TOOLS := poetry
 .PHONY: poetry-tooling poetry-import poetry-clean-cache poetry-clean-venv poetry-clean-lock poetry-lock poetry-install poetry-add-package poetry-version
 poetry-tooling:
-	curl -sSL https://install.python-poetry.org | python3 -
+	pipx install poetry
 	poetry config virtualenvs.in-project true
 poetry-import:
 	cd poetry; poetry add $$(sed -e 's/#.*//' -e '/^$$/ d' < ../requirements.txt)


### PR DESCRIPTION
per https://python-poetry.org/docs/, the first recommended method for installing poetry these days is `pipx`

(which is present in github runner images so this should Just Work)