### PR TITLE
clean pdm venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ pdm-import:
 pdm-clean-cache: pip-clean
 	rm -rf ~/.cache/pdm
 pdm-clean-venv:
-	rm -rf pdm/__pypackages__
+	rm -rf pdm/.venv pdm/__pypackages__
 	mkdir -p pdm/__pypackages__
 pdm-clean-lock:
 	rm -f pdm/pdm.lock


### PR DESCRIPTION
Since their 2.17.0 release, `pdm import` has been creating a traditional virtual environment and installing packages there, rather than doing its pep582 thing.

It is hard to tell whether this is deliberate or not, I find no mention in the changelog.

Anyway from a benchmark point of view the result is that `make pdm-clean-venv` does not clean the pdm venv.  So eg at "warm install" it really has no installing to do at all - unlike all of the other tools.

Since I am not sure that the pdm behaviour change is intended / permanent I have belt-and-braced it: remove both the `.venv` directory and also the `__pypackages__` directory