### PR TITLE
Benchmark: pdm-uv

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -530,7 +530,7 @@ jobs:
 
   gather:
     runs-on: ubuntu-22.04
-    needs: [poetry, pdm, pipenv, pip-tools, uv]
+    needs: [poetry, pdm, pdm-uv, pipenv, pip-tools, uv]
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -184,6 +184,92 @@ jobs:
           path: pdm/stats.csv
           retention-days: 10
 
+  pdm-uv:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: setup
+        run: ./bin/actions_prereqs.sh
+
+      - name: tooling
+        run: |
+          /usr/bin/time --output=timings/tooling.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-tooling
+
+      - name: import
+        run: |
+          /usr/bin/time --output=timings/import.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-import
+
+      - name: lock cold
+        run: |
+          make pdm-uv-clean-cache
+          make pdm-uv-clean-venv
+          make pdm-uv-clean-lock
+          /usr/bin/time --output=timings/lock-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-lock
+
+      - name: lock warm
+        run: |
+          make pdm-uv-clean-lock
+          /usr/bin/time --output=timings/lock-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-lock
+
+      - name: install cold
+        run: |
+          make pdm-uv-clean-cache
+          make pdm-uv-clean-venv
+          /usr/bin/time --output=timings/install-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-install
+
+      - name: install warm
+        run: |
+          make pdm-uv-clean-venv
+          /usr/bin/time --output=timings/install-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-install
+
+      - name: update cold
+        run: |
+          make pdm-uv-clean-cache
+          /usr/bin/time --output=timings/update-cold.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-update
+
+      - name: update warm
+        run: |
+          /usr/bin/time --output=timings/update-warm.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-update
+
+      - name: add package
+        run: |
+          /usr/bin/time --output=timings/add-package.txt --format="%e,%S,%U,%P,%M,%I,%O" \
+            make pdm-uv-add-package
+
+      - name: stats
+        run: |
+          VERSION=$(make pdm-uv-version)
+          CSV=pdm-uv/stats.csv
+          TIMESTAMP=$(date +%s)
+          mkdir -p "pdm-uv"
+          echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
+          for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
+            echo "pdm,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
+          done
+          csv2md "$CSV" >> $GITHUB_STEP_SUMMARY
+
+      - uses: actions/upload-artifact@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: pdm-uv-stats
+          path: pdm-uv/stats.csv
+          retention-days: 10
+
   pipenv:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -259,7 +259,7 @@ jobs:
           mkdir -p "pdm-uv"
           echo "tool,version,timestamp,stat,elapsed time,system,user,cpu percent,max rss,inputs,outputs" > "$CSV"
           for stat in "tooling" "import" "lock-cold" "lock-warm" "install-cold" "install-warm" "update-cold" "update-warm" "add-package"; do
-            echo "pdm,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
+            echo "pdm-uv,$VERSION,$TIMESTAMP,$stat,$(cat timings/$stat.txt | tr -d '%')" >> "$CSV"
           done
           csv2md "$CSV" >> $GITHUB_STEP_SUMMARY
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,32 @@ pdm-add-package:
 pdm-version:
 	@pdm --version | awk '{print $$3}'
 
+TOOLS := "$(TOOLS) pdm-uv"
+.PHONY: pdm-uv-tooling pdm-uv-import pdm-uv-clean-cache pdm-uv-clean-venv pdm-uv-clean-lock pdm-uv-lock pdm-uv-install pdm-uv-add-package pdm-uv-version
+pdm-uv-tooling:
+	pipx install pdm
+	pipx install uv
+	pdm config use_uv true
+	pdm config python.use_venv True
+pdm-uv-import:
+	cd pdm-uv; pdm import -f requirements ../requirements.txt
+pdm-uv-clean-cache: pip-clean
+	rm -rf ~/.cache/pdm
+	rm -rf ~/.cache/uv
+pdm-uv-clean-venv:
+	rm -rf pdm/.venv pdm/__pypackages__
+pdm-uv-clean-lock:
+	rm -f pdm/pdm.lock
+pdm-uv-lock:
+	cd pdm-uv; pdm lock
+pdm-uv-install:
+	cd pdm-uv; pdm install
+pdm-uv-update:
+	cd pdm-uv; pdm update
+pdm-uv-add-package:
+	cd pdm-uv; pdm add $(PACKAGE)
+pdm-uv-version:
+	@echo "PDM ${pdm --version | awk '{print $$3}'} - UV ${uv --version | awk '{print $$2}}"
 
 TOOLS := "$(TOOLS) pipenv"
 .PHONY: pipenv-tooling pipenv-import pipenv-clean-cache pipenv-clean-venv pipenv-clean-lock pipenv-lock pipenv-install pipenv-add-package pipenv-version

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ pdm-uv-update:
 pdm-uv-add-package:
 	cd pdm-uv; pdm add $(PACKAGE)
 pdm-uv-version:
-	@echo "PDM ${pdm --version | awk '{print $$3}'} - UV ${uv --version | awk '{print $$2}}"
+	@echo "pdm$$(pdm --version | awk '{print $$3}')-uv$$(uv --version | awk '{print $$2}')"
 
 TOOLS := "$(TOOLS) pipenv"
 .PHONY: pipenv-tooling pipenv-import pipenv-clean-cache pipenv-clean-venv pipenv-clean-lock pipenv-lock pipenv-install pipenv-add-package pipenv-version

--- a/pdm-uv/pyproject.toml
+++ b/pdm-uv/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "pdm-uv"
+version = "0.0.0"
+description = ""
+authors = [
+    {name = "Your Name", email = "you@example.com"},
+]
+dependencies = []
+requires-python = ">=3.11"
+license = {text = "MIT"}
+
+[build-system]
+requires = ["pdm-pep517>=1.0.0"]
+build-backend = "pdm.pep517.api"


### PR DESCRIPTION
Add an extra benchmark for the (experimental) integration between PDM and UV (used as a resolver), named `pdm-uv`.

NOTE: as version I have used an interpolation between the PDM and the UV versions, as both could have an impact on the benchmark (something like `pdm2.22.2-uv0.5.23`). This is different from all other tools, as they only have a single standard semver number, but I thing it should not create problems as this version is not used for anything other that to be shown to users.

Resolves #28.