### PR TITLE
Add pdm-uv links to index.html

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -99,6 +99,9 @@
         <a href="https://pdm.fming.dev/latest/"><code>pdm</code></a>
       </li>
       <li>
+        <a href="https://pdm-project.org/latest/usage/uv/"><code>pdm &#43; uv (as resolver)</code></a>
+      </li>
+      <li>
         <a href="https://pip-tools.readthedocs.io/"><code>pip-tools</code></a>
         &#43;
         <a href="https://docs.python.org/3/library/venv.html"


### PR DESCRIPTION
Add missing links to `pdm-uv` package manager in `index.html` (the update was missed in #29).