### PR TITLE
Update the `requires-python` range for uv temporarily to fix resolution differences

### DIFF
--- a/uv/pyproject.toml
+++ b/uv/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Your Name", email = "you@example.com"},
 ]
 dependencies = []
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 license = {text = "MIT"}
 
 [tool.uv]


### PR DESCRIPTION
This works around #37 and #38 resolving the big regression in uv cold install performance reported at https://github.com/astral-sh/uv/issues/17831